### PR TITLE
Add Travis CI config. Add .rosinstall file 

### DIFF
--- a/.rosinstall_ci
+++ b/.rosinstall_ci
@@ -1,0 +1,8 @@
+# IT IS UNLIKELY YOU WANT TO EDIT THIS FILE BY HAND,
+# UNLESS FOR REMOVING ENTRIES.
+# IF YOU WANT TO CHANGE THE ROS ENVIRONMENT VARIABLES
+# USE THE rosinstall TOOL INSTEAD.
+# IF YOU CHANGE IT, USE rosinstall FOR THE CHANGES TO TAKE EFFECT
+- git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git',
+    version: master}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    on_failure: always
+    recipients:
+      - gm130s@gmail.com
+env:
+  - ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu ROSINSTALL_FILENAME=".rosinstall_ci" UPSTREAM_WORKSPACE="file"
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+script:
+  - source .industrial_ci/travis.sh

--- a/package.xml
+++ b/package.xml
@@ -9,5 +9,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
+  <depend>swig</depend>
 
 </package>


### PR DESCRIPTION
`rosdep` key for `catkin_simple` is not available, so running `rosdep install` fails (typically on CI. E.g. for https://github.com/tradr-project/tensorflow_ros/pull/7, CI [output sample](https://travis-ci.org/130s/tensorflow_ros/builds/391452035#L549)).

Also, opening this to a fork `plusone-robotics` as https://github.com/plusone-robotics/tensorflow_catkin/pull/1 doesn't seem to be pushed back to the origin yet.